### PR TITLE
Expose package typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # React Arbiter Changelog
 
+## 0.7.2
+
+- Expose package typings 
+
 ## 0.7.1
 
 - Drop new modules if they would override existing modules

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "react-arbiter",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Recall all your modules to extend your SPA dynamically at runtime.",
   "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "scripts": {
     "lint": "tslint -c tslint.json 'src/**/*.{ts,tsx}'",
     "build": "tsc --project tsconfig.json",


### PR DESCRIPTION
Just a little PR to allow better TS support when importing the lib.

So when doing
`import { Something } from "react-arbiter";`
TS is able to jump to declarations directly.

Regards!